### PR TITLE
ダッシュボードの予約数カウントとUIの日本語化

### DIFF
--- a/vite-app-ant/src/App.tsx
+++ b/vite-app-ant/src/App.tsx
@@ -60,7 +60,6 @@ import { DashboardOutlined } from "@ant-design/icons";
 function App() {
   return (
     (<BrowserRouter>
-      <GitHubBanner />
       <RefineKbarProvider>
         <ColorModeContextProvider>
           <AntdApp>

--- a/vite-app-ant/src/locale/en.json
+++ b/vite-app-ant/src/locale/en.json
@@ -1,0 +1,174 @@
+{
+  "pages": {
+    "login": {
+      "__description": "These keys are used by the <AuthPage type='login' /> components.",
+      "title": "Sign in to your account",
+      "signin": "Sign in",
+      "signup": "Sign up",
+      "divider": "or",
+      "fields": {
+        "email": "Email",
+        "password": "Password"
+      },
+      "errors": {
+        "validEmail": "Invalid email address",
+        "requiredEmail": "Email is required",
+        "requiredPassword": "Password is required"
+      },
+      "buttons": {
+        "submit": "Login",
+        "forgotPassword": "Forgot password?",
+        "noAccount": "Don’t have an account?",
+        "rememberMe": "Remember me"
+      }
+    },
+    "forgotPassword": {
+      "__description": "These key are used by the <AuthPage type='forgotPassword' /> components.",
+      "title": "Forgot your password?",
+      "signin": "Sign in",
+      "fields": {
+        "email": "Email"
+      },
+      "errors": {
+        "validEmail": "Invalid email address",
+        "requiredEmail": "Email is required"
+      },
+      "buttons": {
+        "submit": "Send reset instructions",
+        "haveAccount": "Have an account?"
+      }
+    },
+    "register": {
+      "__description": "These keys are used by the <AuthPage type='register' /> components.",
+      "title": "Sign up for your account",
+      "signin": "Sign in",
+      "divider": "or",
+      "fields": {
+        "email": "Email",
+        "password": "Password"
+      },
+      "errors": {
+        "validEmail": "Invalid email address",
+        "requiredEmail": "Email is required",
+        "requiredPassword": "Password is required"
+      },
+      "buttons": {
+        "submit": "Register",
+        "haveAccount": "Have an account?"
+      }
+    },
+    "updatePassword": {
+      "__description": "These keys are used by the <AuthPage type='updatePassword' /> components.",
+      "title": "Update password",
+      "fields": {
+        "password": "New Password",
+        "confirmPassword": "Confirm new password"
+      },
+      "errors": {
+        "confirmPasswordNotMatch": "Passwords do not match",
+        "requiredPassword": "Password required",
+        "requiredConfirmPassword": "Confirm password is required"
+      },
+      "buttons": {
+        "submit": "Update"
+      }
+    },
+    "error": {
+      "__description": "These keys are used by the <ErrorPage /> components.",
+      "info": "You may have forgotten to add the {{action}} component to {{resource}} resource.",
+      "404": "Sorry, the page you visited does not exist.",
+      "resource404": "Are you sure you have created the {{resource}} resource.",
+      "backHome": "Back Home"
+    }
+  },
+  "actions": {
+    "__description": "These keys are used by the @refinedev/kbar package.",
+    "list": "List",
+    "create": "Create",
+    "edit": "Edit",
+    "show": "Show"
+  },
+  "buttons": {
+    "__description": "These keys are used by the buttons and breadcrumbs.",
+    "create": "Create",
+    "save": "Save",
+    "logout": "Logout",
+    "delete": "Delete",
+    "edit": "Edit",
+    "cancel": "Cancel",
+    "confirm": "Are you sure?",
+    "filter": "Filter",
+    "clear": "Clear",
+    "refresh": "Refresh",
+    "show": "Show",
+    "undo": "Undo",
+    "import": "Import",
+    "clone": "Clone",
+    "notAccessTitle": "You don't have permission to access"
+  },
+  "warnWhenUnsavedChanges": "Are you sure you want to leave? You have unsaved changes.",
+  "notifications": {
+    "__description": "These keys are used by the notification provider.",
+    "success": "Successful",
+    "error": "Error (status code: {{statusCode}})",
+    "undoable": "You have {{seconds}} seconds to undo",
+    "createSuccess": "Successfully created {{resource}}",
+    "createError": "There was an error creating {{resource}} (status code: {{statusCode}})",
+    "deleteSuccess": "Successfully deleted {{resource}}",
+    "deleteError": "Error when deleting {{resource}} (status code: {{statusCode}})",
+    "editSuccess": "Successfully edited {{resource}}",
+    "editError": "Error when editing {{resource}} (status code: {{statusCode}})",
+    "importProgress": "Importing: {{processed}}/{{total}}"
+  },
+  "loading": "Loading",
+  "dashboard": {
+    "__description": "This key is used by <Layout /> components to display the dashboard item in sidebar.",
+    "title": "Dashboard"
+  },
+  "posts": {
+    "__description": "These keys are used in translations for the 'posts' resource.",
+    "posts": "Posts",
+    "fields": {
+      "id": "Id",
+      "title": "Title",
+      "category": "Category",
+      "status": {
+        "title": "Status",
+        "published": "Published",
+        "draft": "Draft",
+        "rejected": "Rejected"
+      },
+      "content": "Content",
+      "createdAt": "Created At"
+    },
+    "titles": {
+      "create": "Create Post",
+      "edit": "Edit Post",
+      "list": "Posts",
+      "show": "Show Post"
+    }
+  },
+  "table": {
+    "__description": "This key is used by Inferencer components in 'list' views.",
+    "actions": "Actions"
+  },
+  "documentTitle": {
+    "__description": "These keys are used by the <DocumentTitleHandler /> components.",
+    "default": "refine",
+    "suffix": " | Refine",
+    "post": {
+      "list": "Posts | Refine",
+      "show": "#{{id}} Show Post | Refine",
+      "edit": "#{{id}} Edit Post | Refine",
+      "create": "Create new Post | Refine",
+      "clone": "#{{id}} Clone Post | Refine"
+    }
+  },
+  "autoSave": {
+    "__description": "These keys are used by the <AutoSaveIndicator /> and the auto-save feature.",
+    "success": "saved",
+    "error": "auto save failure",
+    "loading": "saving...",
+    "idle": "waiting for changes"
+  }
+}

--- a/vite-app-ant/src/pages/dashboard/index.tsx
+++ b/vite-app-ant/src/pages/dashboard/index.tsx
@@ -61,7 +61,10 @@ export const DashboardPage: React.FC = () => {
       pageSize: 100,
     },
     meta: {
-      select: "*, lessons(name, max_participants), profiles!instructor_id(first_name, last_name)",
+      select: `*,
+        lessons!inner(name, max_participants),
+        profiles!instructor_id(first_name, last_name),
+        reservations!lesson_schedule_id(status)`,
     },
   });
 
@@ -258,9 +261,9 @@ export const DashboardPage: React.FC = () => {
     },
     {
       title: "参加人数",
-      dataIndex: "current_participants",
-      render: (value: number, record: any) => {
-        const currentParticipants = value || 0;
+      render: (_: any, record: any) => {
+        const reservations = record.reservations || [];
+        const currentParticipants = reservations.filter((r: any) => r.status !== 'キャンセル').length;
         const maxParticipants = record.lessons?.max_participants || 0;
         return `${currentParticipants}/${maxParticipants}`;
       },

--- a/vite-app-ant/src/pages/instructor_schedules/create.tsx
+++ b/vite-app-ant/src/pages/instructor_schedules/create.tsx
@@ -10,68 +10,43 @@ export const InstructorSchedulesCreate = () => {
         <Create saveButtonProps={saveButtonProps}>
             <Form {...formProps} layout="vertical">
                 <Form.Item
-                    label="Date"
+                    label="勤務日"
                     name={["date"]}
                     rules={[
                         {
                             required: true,
+                            message: "勤務日を選択してください",
                         },
                     ]}
                     getValueProps={(value) => ({
                         value: value ? dayjs(value) : undefined,
                     })}
                 >
-                    <DatePicker />
+                    <DatePicker format="YYYY年MM月DD日" />
                 </Form.Item>
                 <Form.Item
-                    label="Start Time"
+                    label="開始時間"
                     name={["start_time"]}
                     rules={[
                         {
                             required: true,
+                            message: "開始時間を入力してください",
                         },
                     ]}
                 >
                     <Input />
                 </Form.Item>
                 <Form.Item
-                    label="End Time"
+                    label="終了時間"
                     name={["end_time"]}
                     rules={[
                         {
                             required: true,
+                            message: "終了時間を入力してください",
                         },
                     ]}
                 >
                     <Input />
-                </Form.Item>
-                <Form.Item
-                    label="Created At"
-                    name={["created_at"]}
-                    rules={[
-                        {
-                            required: true,
-                        },
-                    ]}
-                    getValueProps={(value) => ({
-                        value: value ? dayjs(value) : undefined,
-                    })}
-                >
-                    <DatePicker />
-                </Form.Item>
-                <Form.Item
-                    label="Updated At"
-                    name={["updated_at"]}
-                    rules={[
-                        {
-                            required: true,
-                        },
-                    ]}
-                    getValueProps={(value) => ({
-                        value: value ? dayjs(value) : undefined,
-                    })}
-                >
-                    <DatePicker />
                 </Form.Item>
             </Form>
         </Create>

--- a/vite-app-ant/src/pages/instructor_schedules/edit.tsx
+++ b/vite-app-ant/src/pages/instructor_schedules/edit.tsx
@@ -12,7 +12,7 @@ export const InstructorSchedulesEdit = () => {
         <Edit saveButtonProps={saveButtonProps}>
             <Form {...formProps} layout="vertical">
                 <Form.Item
-                    label="Id"
+                    label="ID"
                     name={["id"]}
                     rules={[
                         {
@@ -23,68 +23,43 @@ export const InstructorSchedulesEdit = () => {
                     <Input readOnly disabled />
                 </Form.Item>
                 <Form.Item
-                    label="Date"
+                    label="勤務日"
                     name={["date"]}
                     rules={[
                         {
                             required: true,
+                            message: "勤務日を選択してください",
                         },
                     ]}
                     getValueProps={(value) => ({
                         value: value ? dayjs(value) : undefined,
                     })}
                 >
-                    <DatePicker />
+                    <DatePicker format="YYYY年MM月DD日" />
                 </Form.Item>
                 <Form.Item
-                    label="Start Time"
+                    label="開始時間"
                     name={["start_time"]}
                     rules={[
                         {
                             required: true,
+                            message: "開始時間を入力してください",
                         },
                     ]}
                 >
                     <Input />
                 </Form.Item>
                 <Form.Item
-                    label="End Time"
+                    label="終了時間"
                     name={["end_time"]}
                     rules={[
                         {
                             required: true,
+                            message: "終了時間を入力してください",
                         },
                     ]}
                 >
                     <Input />
-                </Form.Item>
-                <Form.Item
-                    label="Created At"
-                    name={["created_at"]}
-                    rules={[
-                        {
-                            required: true,
-                        },
-                    ]}
-                    getValueProps={(value) => ({
-                        value: value ? dayjs(value) : undefined,
-                    })}
-                >
-                    <DatePicker />
-                </Form.Item>
-                <Form.Item
-                    label="Updated At"
-                    name={["updated_at"]}
-                    rules={[
-                        {
-                            required: true,
-                        },
-                    ]}
-                    getValueProps={(value) => ({
-                        value: value ? dayjs(value) : undefined,
-                    })}
-                >
-                    <DatePicker />
                 </Form.Item>
             </Form>
         </Edit>

--- a/vite-app-ant/src/pages/instructor_schedules/show.tsx
+++ b/vite-app-ant/src/pages/instructor_schedules/show.tsx
@@ -8,6 +8,11 @@ import {
     DateField,
 } from "@refinedev/antd";
 import { Table, Space } from "antd";
+import { useShow } from "@refinedev/core";
+import { Show, TagField, TextField } from "@refinedev/antd";
+import { Typography } from "antd";
+
+const { Title } = Typography;
 
 export const InstructorSchedulesShow = () => {
     const { tableProps } = useTable({
@@ -21,6 +26,11 @@ export const InstructorSchedulesShow = () => {
             enabled: !!tableProps?.dataSource,
         },
     });
+
+    const { queryResult } = useShow();
+    const { data, isLoading } = queryResult;
+
+    const record = data?.data;
 
     return (
         <List>
@@ -79,6 +89,21 @@ export const InstructorSchedulesShow = () => {
                     )}
                 />
             </Table>
+
+            <Show isLoading={isLoading}>
+                <Title level={5}>インストラクターID</Title>
+                <TextField value={record?.instructor_id} />
+                <Title level={5}>勤務日</Title>
+                <DateField value={record?.date} format="YYYY年MM月DD日" />
+                <Title level={5}>開始時間</Title>
+                <TextField value={record?.start_time} />
+                <Title level={5}>終了時間</Title>
+                <TextField value={record?.end_time} />
+                <Title level={5}>作成日時</Title>
+                <DateField value={record?.created_at} format="YYYY年MM月DD日 HH時mm分" />
+                <Title level={5}>更新日時</Title>
+                <DateField value={record?.updated_at} format="YYYY年MM月DD日 HH時mm分" />
+            </Show>
         </List>
     );
 };

--- a/vite-app-ant/src/pages/lesson_levels/show.tsx
+++ b/vite-app-ant/src/pages/lesson_levels/show.tsx
@@ -1,5 +1,28 @@
-import { AntdInferencer } from "@refinedev/inferencer/antd";
+import React from "react";
+import { useShow } from "@refinedev/core";
+import { Show, TagField, TextField, DateField } from "@refinedev/antd";
+import { Typography } from "antd";
+
+const { Title } = Typography;
 
 export const LessonLevelsShow = () => {
-    return <AntdInferencer />;
+    const { queryResult } = useShow();
+    const { data, isLoading } = queryResult;
+
+    const record = data?.data;
+
+    return (
+        <Show isLoading={isLoading}>
+            <Title level={5}>レッスンレベルID</Title>
+            <TextField value={record?.id} />
+            <Title level={5}>レベル名</Title>
+            <TextField value={record?.name} />
+            <Title level={5}>説明</Title>
+            <TextField value={record?.description} />
+            <Title level={5}>作成日時</Title>
+            <DateField value={record?.created_at} format="YYYY年MM月DD日 HH時mm分" />
+            <Title level={5}>更新日時</Title>
+            <DateField value={record?.updated_at} format="YYYY年MM月DD日 HH時mm分" />
+        </Show>
+    );
 };

--- a/vite-app-ant/src/pages/lesson_schedules/create.tsx
+++ b/vite-app-ant/src/pages/lesson_schedules/create.tsx
@@ -15,82 +15,58 @@ export const LessonSchedulesCreate = () => {
         <Create saveButtonProps={saveButtonProps}>
             <Form {...formProps} layout="vertical">
                 <Form.Item
-                    label="Lesson"
+                    label="レッスン"
                     name={"lesson_id"}
                     rules={[
                         {
                             required: true,
+                            message: "レッスンを選択してください",
                         },
                     ]}
                 >
                     <Select {...lessonSelectProps} />
                 </Form.Item>
                 <Form.Item
-                    label="Start Time"
+                    label="開始時間"
                     name={["start_time"]}
                     rules={[
                         {
                             required: true,
+                            message: "開始時間を選択してください",
                         },
                     ]}
                     getValueProps={(value) => ({
                         value: value ? dayjs(value) : undefined,
                     })}
                 >
-                    <DatePicker />
+                    <DatePicker format="YYYY年MM月DD日 HH時mm分" showTime={{ format: 'HH:mm' }} />
                 </Form.Item>
                 <Form.Item
-                    label="End Time"
+                    label="終了時間"
                     name={["end_time"]}
                     rules={[
                         {
                             required: true,
+                            message: "終了時間を選択してください",
                         },
                     ]}
                     getValueProps={(value) => ({
                         value: value ? dayjs(value) : undefined,
                     })}
                 >
-                    <DatePicker />
+                    <DatePicker format="YYYY年MM月DD日 HH時mm分" showTime={{ format: 'HH:mm' }} />
                 </Form.Item>
                 <Form.Item
-                    label="Status"
+                    label="ステータス"
                     name={["status"]}
                     rules={[
                         {
                             required: true,
+                            message: "ステータスを入力してください",
                         },
                     ]}
                 >
                     <Input />
-                </Form.Item>
-                <Form.Item
-                    label="Created At"
-                    name={["created_at"]}
-                    rules={[
-                        {
-                            required: true,
-                        },
-                    ]}
-                    getValueProps={(value) => ({
-                        value: value ? dayjs(value) : undefined,
-                    })}
-                >
-                    <DatePicker />
-                </Form.Item>
-                <Form.Item
-                    label="Updated At"
-                    name={["updated_at"]}
-                    rules={[
-                        {
-                            required: true,
-                        },
-                    ]}
-                    getValueProps={(value) => ({
-                        value: value ? dayjs(value) : undefined,
-                    })}
-                >
-                    <DatePicker />
                 </Form.Item>
             </Form>
         </Create>

--- a/vite-app-ant/src/pages/lesson_schedules/edit.tsx
+++ b/vite-app-ant/src/pages/lesson_schedules/edit.tsx
@@ -18,7 +18,7 @@ export const LessonSchedulesEdit = () => {
         <Edit saveButtonProps={saveButtonProps}>
             <Form {...formProps} layout="vertical">
                 <Form.Item
-                    label="Id"
+                    label="ID"
                     name={["id"]}
                     rules={[
                         {
@@ -29,82 +29,58 @@ export const LessonSchedulesEdit = () => {
                     <Input readOnly disabled />
                 </Form.Item>
                 <Form.Item
-                    label="Lesson"
+                    label="レッスン"
                     name={"lesson_id"}
                     rules={[
                         {
                             required: true,
+                            message: "レッスンを選択してください",
                         },
                     ]}
                 >
                     <Select {...lessonSelectProps} />
                 </Form.Item>
                 <Form.Item
-                    label="Start Time"
+                    label="開始時間"
                     name={["start_time"]}
                     rules={[
                         {
                             required: true,
+                            message: "開始時間を選択してください",
                         },
                     ]}
                     getValueProps={(value) => ({
                         value: value ? dayjs(value) : undefined,
                     })}
                 >
-                    <DatePicker />
+                    <DatePicker format="YYYY年MM月DD日 HH時mm分" showTime={{ format: 'HH:mm' }} />
                 </Form.Item>
                 <Form.Item
-                    label="End Time"
+                    label="終了時間"
                     name={["end_time"]}
                     rules={[
                         {
                             required: true,
+                            message: "終了時間を選択してください",
                         },
                     ]}
                     getValueProps={(value) => ({
                         value: value ? dayjs(value) : undefined,
                     })}
                 >
-                    <DatePicker />
+                    <DatePicker format="YYYY年MM月DD日 HH時mm分" showTime={{ format: 'HH:mm' }} />
                 </Form.Item>
                 <Form.Item
-                    label="Status"
+                    label="ステータス"
                     name={["status"]}
                     rules={[
                         {
                             required: true,
+                            message: "ステータスを入力してください",
                         },
                     ]}
                 >
                     <Input />
-                </Form.Item>
-                <Form.Item
-                    label="Created At"
-                    name={["created_at"]}
-                    rules={[
-                        {
-                            required: true,
-                        },
-                    ]}
-                    getValueProps={(value) => ({
-                        value: value ? dayjs(value) : undefined,
-                    })}
-                >
-                    <DatePicker />
-                </Form.Item>
-                <Form.Item
-                    label="Updated At"
-                    name={["updated_at"]}
-                    rules={[
-                        {
-                            required: true,
-                        },
-                    ]}
-                    getValueProps={(value) => ({
-                        value: value ? dayjs(value) : undefined,
-                    })}
-                >
-                    <DatePicker />
                 </Form.Item>
             </Form>
         </Edit>

--- a/vite-app-ant/src/pages/lesson_schedules/list.tsx
+++ b/vite-app-ant/src/pages/lesson_schedules/list.tsx
@@ -1,5 +1,84 @@
-import { AntdInferencer } from "@refinedev/inferencer/antd";
+import React from "react";
+import { BaseRecord, useMany } from "@refinedev/core";
+import {
+    useTable,
+    List,
+    EditButton,
+    ShowButton,
+    DateField,
+} from "@refinedev/antd";
+import { Table, Space } from "antd";
 
 export const LessonSchedulesList = () => {
-    return <AntdInferencer />;
+    const { tableProps } = useTable({
+        syncWithLocation: true,
+    });
+
+    const { data: lessonData, isLoading: lessonIsLoading } = useMany({
+        resource: "lessons",
+        ids: tableProps?.dataSource?.map((item) => item?.lesson_id) ?? [],
+        queryOptions: {
+            enabled: !!tableProps?.dataSource,
+        },
+    });
+
+    return (
+        <List>
+            <Table {...tableProps} rowKey="id">
+                <Table.Column dataIndex="id" title="Id" />
+                <Table.Column
+                    dataIndex={["lesson_id"]}
+                    title="Lesson"
+                    render={(value) =>
+                        lessonIsLoading ? (
+                            <>Loading...</>
+                        ) : (
+                            lessonData?.data?.find((item) => item.id === value)
+                                ?.name
+                        )
+                    }
+                />
+
+                <Table.Column
+                    dataIndex={["start_time"]}
+                    title="Start Time"
+                    render={(value: any) => <DateField value={value} />}
+                />
+                <Table.Column
+                    dataIndex={["end_time"]}
+                    title="End Time"
+                    render={(value: any) => <DateField value={value} />}
+                />
+                <Table.Column dataIndex="status" title="Status" />
+                <Table.Column
+                    dataIndex={["created_at"]}
+                    title="Created At"
+                    render={(value: any) => <DateField value={value} />}
+                />
+                <Table.Column
+                    dataIndex={["updated_at"]}
+                    title="Updated At"
+                    render={(value: any) => <DateField value={value} />}
+                />
+                <Table.Column
+                    title="Actions"
+                    dataIndex="actions"
+                    render={(_, record: BaseRecord) => (
+                        <Space>
+                            <EditButton
+                                hideText
+                                size="small"
+                                recordItemId={record.id}
+                            />
+                            <ShowButton
+                                hideText
+                                size="small"
+                                recordItemId={record.id}
+                            />
+                        </Space>
+                    )}
+                />
+            </Table>
+        </List>
+    );
 };

--- a/vite-app-ant/src/pages/lesson_schedules/show.tsx
+++ b/vite-app-ant/src/pages/lesson_schedules/show.tsx
@@ -35,12 +35,14 @@ export const LessonSchedulesShow = () => {
                     emergency_contact
                 )
             `,
-            filter: {
-                lesson_schedule_id: {
-                    eq: record?.id,
-                },
-            },
         },
+        filters:[
+            {
+                field: "lesson_schedule_id",
+                operator: "eq",
+                value: record?.id,
+            }
+        ]
     });
 
     console.log('reservationsData:', reservationsData); // デバッグ用
@@ -91,20 +93,20 @@ export const LessonSchedulesShow = () => {
                 rowKey="id"
             />
 
-            <Title level={5}>Id</Title>
+            <Title level={5}>レッスンスケジュールID</Title>
             <TextField value={record?.id} />
-            <Title level={5}>Lesson</Title>
+            <Title level={5}>レッスン</Title>
             {lessonIsLoading ? <>Loading...</> : <>{lessonData?.data?.name}</>}
-            <Title level={5}>Start Time</Title>
-            <DateField value={record?.start_time} />
-            <Title level={5}>End Time</Title>
-            <DateField value={record?.end_time} />
-            <Title level={5}>Status</Title>
+            <Title level={5}>開始時間</Title>
+            <DateField value={record?.start_time} format="YYYY年MM月DD日 HH時mm分" />
+            <Title level={5}>終了時間</Title>
+            <DateField value={record?.end_time} format="YYYY年MM月DD日 HH時mm分" />
+            <Title level={5}>ステータス</Title>
             <TextField value={record?.status} />
-            <Title level={5}>Created At</Title>
-            <DateField value={record?.created_at} />
-            <Title level={5}>Updated At</Title>
-            <DateField value={record?.updated_at} />
+            <Title level={5}>作成日時</Title>
+            <DateField value={record?.created_at} format="YYYY年MM月DD日 HH時mm分" />
+            <Title level={5}>更新日時</Title>
+            <DateField value={record?.updated_at} format="YYYY年MM月DD日 HH時mm分" />
         </Show>
     );
 };

--- a/vite-app-ant/src/pages/lessons/create.tsx
+++ b/vite-app-ant/src/pages/lessons/create.tsx
@@ -1,5 +1,98 @@
-import { AntdInferencer } from "@refinedev/inferencer/antd";
+import React from "react";
+import { Create, useForm } from "@refinedev/antd";
+import { Form, Input, DatePicker } from "antd";
+import dayjs from "dayjs";
 
 export const LessonsCreate = () => {
-    return <AntdInferencer />;
+    const { formProps, saveButtonProps, query } = useForm();
+
+    return (
+        <Create saveButtonProps={saveButtonProps}>
+            <Form {...formProps} layout="vertical">
+                <Form.Item
+                    label="Name"
+                    name={["name"]}
+                    rules={[
+                        {
+                            required: true,
+                        },
+                    ]}
+                >
+                    <Input />
+                </Form.Item>
+                <Form.Item
+                    label="Description"
+                    name={["description"]}
+                    rules={[
+                        {
+                            required: true,
+                        },
+                    ]}
+                >
+                    <Input />
+                </Form.Item>
+                <Form.Item
+                    label="Duration"
+                    name={["duration"]}
+                    rules={[
+                        {
+                            required: true,
+                        },
+                    ]}
+                >
+                    <Input />
+                </Form.Item>
+                <Form.Item
+                    label="Price"
+                    name={["price"]}
+                    rules={[
+                        {
+                            required: true,
+                        },
+                    ]}
+                >
+                    <Input />
+                </Form.Item>
+                <Form.Item
+                    label="Max Participants"
+                    name={["max_participants"]}
+                    rules={[
+                        {
+                            required: true,
+                        },
+                    ]}
+                >
+                    <Input />
+                </Form.Item>
+                <Form.Item
+                    label="Created At"
+                    name={["created_at"]}
+                    rules={[
+                        {
+                            required: true,
+                        },
+                    ]}
+                    getValueProps={(value) => ({
+                        value: value ? dayjs(value) : undefined,
+                    })}
+                >
+                    <DatePicker />
+                </Form.Item>
+                <Form.Item
+                    label="Updated At"
+                    name={["updated_at"]}
+                    rules={[
+                        {
+                            required: true,
+                        },
+                    ]}
+                    getValueProps={(value) => ({
+                        value: value ? dayjs(value) : undefined,
+                    })}
+                >
+                    <DatePicker />
+                </Form.Item>
+            </Form>
+        </Create>
+    );
 };

--- a/vite-app-ant/src/pages/lessons/edit.tsx
+++ b/vite-app-ant/src/pages/lessons/edit.tsx
@@ -12,7 +12,7 @@ export const LessonsEdit = () => {
         <Edit saveButtonProps={saveButtonProps}>
             <Form {...formProps} layout="vertical">
                 <Form.Item
-                    label="Id"
+                    label="ID"
                     name={["id"]}
                     rules={[
                         {
@@ -23,87 +23,64 @@ export const LessonsEdit = () => {
                     <Input readOnly disabled />
                 </Form.Item>
                 <Form.Item
-                    label="Name"
+                    label="レッスン名"
                     name={["name"]}
                     rules={[
                         {
                             required: true,
+                            message: "レッスン名を入力してください",
                         },
                     ]}
                 >
                     <Input />
                 </Form.Item>
                 <Form.Item
-                    label="Description"
+                    label="説明"
                     name={["description"]}
                     rules={[
                         {
                             required: true,
+                            message: "説明を入力してください",
                         },
                     ]}
                 >
                     <Input />
                 </Form.Item>
                 <Form.Item
-                    label="Duration"
+                    label="所要時間（分）"
                     name={["duration"]}
                     rules={[
                         {
                             required: true,
+                            message: "所要時間を入力してください",
                         },
                     ]}
                 >
                     <Input />
                 </Form.Item>
                 <Form.Item
-                    label="Price"
+                    label="料金"
                     name={["price"]}
                     rules={[
                         {
                             required: true,
+                            message: "料金を入力してください",
                         },
                     ]}
                 >
                     <Input />
                 </Form.Item>
                 <Form.Item
-                    label="Max Participants"
+                    label="最大参加人数"
                     name={["max_participants"]}
                     rules={[
                         {
                             required: true,
+                            message: "最大参加人数を入力してください",
                         },
                     ]}
                 >
                     <Input />
-                </Form.Item>
-                <Form.Item
-                    label="Created At"
-                    name={["created_at"]}
-                    rules={[
-                        {
-                            required: true,
-                        },
-                    ]}
-                    getValueProps={(value) => ({
-                        value: value ? dayjs(value) : undefined,
-                    })}
-                >
-                    <DatePicker />
-                </Form.Item>
-                <Form.Item
-                    label="Updated At"
-                    name={["updated_at"]}
-                    rules={[
-                        {
-                            required: true,
-                        },
-                    ]}
-                    getValueProps={(value) => ({
-                        value: value ? dayjs(value) : undefined,
-                    })}
-                >
-                    <DatePicker />
                 </Form.Item>
             </Form>
         </Edit>

--- a/vite-app-ant/src/pages/lessons/show.tsx
+++ b/vite-app-ant/src/pages/lessons/show.tsx
@@ -12,29 +12,29 @@ import { Typography } from "antd";
 const { Title } = Typography;
 
 export const LessonsShow = () => {
-    const { query } = useShow();
-    const { data, isLoading } = query;
+    const { queryResult } = useShow();
+    const { data, isLoading } = queryResult;
 
     const record = data?.data;
 
     return (
         <Show isLoading={isLoading}>
-            <Title level={5}>Id</Title>
+            <Title level={5}>レッスンID</Title>
             <TextField value={record?.id} />
-            <Title level={5}>Name</Title>
+            <Title level={5}>レッスン名</Title>
             <TextField value={record?.name} />
-            <Title level={5}>Description</Title>
+            <Title level={5}>説明</Title>
             <TextField value={record?.description} />
-            <Title level={5}>Duration</Title>
+            <Title level={5}>所要時間（分）</Title>
             <NumberField value={record?.duration ?? ""} />
-            <Title level={5}>Price</Title>
+            <Title level={5}>料金</Title>
             <NumberField value={record?.price ?? ""} />
-            <Title level={5}>Max Participants</Title>
+            <Title level={5}>最大参加人数</Title>
             <NumberField value={record?.max_participants ?? ""} />
-            <Title level={5}>Created At</Title>
-            <DateField value={record?.created_at} />
-            <Title level={5}>Updated At</Title>
-            <DateField value={record?.updated_at} />
+            <Title level={5}>作成日時</Title>
+            <DateField value={record?.created_at} format="YYYY年MM月DD日 HH時mm分" />
+            <Title level={5}>更新日時</Title>
+            <DateField value={record?.updated_at} format="YYYY年MM月DD日 HH時mm分" />
         </Show>
     );
 };

--- a/vite-app-ant/src/pages/profiles/show.tsx
+++ b/vite-app-ant/src/pages/profiles/show.tsx
@@ -1,5 +1,34 @@
-import { AntdInferencer } from "@refinedev/inferencer/antd";
+import React from "react";
+import { useShow } from "@refinedev/core";
+import { Show, TagField, TextField, DateField } from "@refinedev/antd";
+import { Typography } from "antd";
+
+const { Title } = Typography;
 
 export const ProfilesShow = () => {
-    return <AntdInferencer />;
+    const { queryResult } = useShow();
+    const { data, isLoading } = queryResult;
+
+    const record = data?.data;
+
+    return (
+        <Show isLoading={isLoading}>
+            <Title level={5}>プロフィールID</Title>
+            <TextField value={record?.id} />
+            <Title level={5}>姓</Title>
+            <TextField value={record?.last_name} />
+            <Title level={5}>名</Title>
+            <TextField value={record?.first_name} />
+            <Title level={5}>電話番号</Title>
+            <TextField value={record?.phone} />
+            <Title level={5}>緊急連絡先名</Title>
+            <TextField value={record?.emergency_contact_name} />
+            <Title level={5}>緊急連絡先電話番号</Title>
+            <TextField value={record?.emergency_contact_phone} />
+            <Title level={5}>作成日時</Title>
+            <DateField value={record?.created_at} format="YYYY年MM月DD日 HH時mm分" />
+            <Title level={5}>更新日時</Title>
+            <DateField value={record?.updated_at} format="YYYY年MM月DD日 HH時mm分" />
+        </Show>
+    );
 };

--- a/vite-app-ant/src/pages/reservations/edit.tsx
+++ b/vite-app-ant/src/pages/reservations/edit.tsx
@@ -17,7 +17,7 @@ export const ReservationsEdit = () => {
         <Edit saveButtonProps={saveButtonProps}>
             <Form {...formProps} layout="vertical">
                 <Form.Item
-                    label="Id"
+                    label="ID"
                     name={["id"]}
                     rules={[
                         {
@@ -28,79 +28,62 @@ export const ReservationsEdit = () => {
                     <Input readOnly disabled />
                 </Form.Item>
                 <Form.Item
-                    label="Lesson Schedule"
+                    label="レッスンスケジュール"
                     name={"lesson_schedule_id"}
                     rules={[
                         {
                             required: true,
+                            message: "レッスンスケジュールを選択してください",
                         },
                     ]}
                 >
                     <Select {...lessonScheduleSelectProps} />
                 </Form.Item>
                 <Form.Item
-                    label="Reservation Number"
+                    label="予約番号"
                     name={["reservation_number"]}
                     rules={[
                         {
                             required: true,
+                            message: "予約番号を選択してください",
                         },
                     ]}
                     getValueProps={(value) => ({
                         value: value ? dayjs(value) : undefined,
                     })}
                 >
-                    <DatePicker />
+                    <DatePicker format="YYYY年MM月DD日" />
                 </Form.Item>
                 <Form.Item
-                    label="Status"
+                    label="ステータス"
                     name={["status"]}
                     rules={[
                         {
                             required: true,
+                            message: "ステータスを入力してください",
                         },
                     ]}
                 >
-                    <Input />
+                    <Select
+                        options={[
+                            { label: "申し込み", value: "申し込み" },
+                            { label: "申し込み承認", value: "申し込み承認" },
+                            { label: "受講済", value: "受講済" },
+                            { label: "キャンセル", value: "キャンセル" },
+                        ]}
+                    />
                 </Form.Item>
                 <Form.Item
-                    label="Instructor Comment"
+                    label="インストラクターコメント"
                     name={["instructor_comment"]}
                     rules={[
                         {
                             required: true,
+                            message: "インストラクターコメントを入力してください",
                         },
                     ]}
                 >
                     <Input />
-                </Form.Item>
-                <Form.Item
-                    label="Created At"
-                    name={["created_at"]}
-                    rules={[
-                        {
-                            required: true,
-                        },
-                    ]}
-                    getValueProps={(value) => ({
-                        value: value ? dayjs(value) : undefined,
-                    })}
-                >
-                    <DatePicker />
-                </Form.Item>
-                <Form.Item
-                    label="Updated At"
-                    name={["updated_at"]}
-                    rules={[
-                        {
-                            required: true,
-                        },
-                    ]}
-                    getValueProps={(value) => ({
-                        value: value ? dayjs(value) : undefined,
-                    })}
-                >
-                    <DatePicker />
                 </Form.Item>
             </Form>
         </Edit>

--- a/vite-app-ant/src/pages/reservations/list.tsx
+++ b/vite-app-ant/src/pages/reservations/list.tsx
@@ -1,5 +1,112 @@
-import { AntdInferencer } from "@refinedev/inferencer/antd";
+import React from "react";
+import { Edit, useForm, useSelect } from "@refinedev/antd";
+import { Form, Input, Select, DatePicker } from "antd";
+import dayjs from "dayjs";
 
 export const ReservationsList = () => {
-    return <AntdInferencer />;
+    const { formProps, saveButtonProps, query } = useForm();
+
+    const Data = query?.data?.data;
+
+    const { selectProps: lessonSelectProps } = useSelect({
+        resource: "lessons",
+        defaultValue: Data?.lesson_id,
+        optionLabel: "name",
+    });
+
+    return (
+        <Edit saveButtonProps={saveButtonProps}>
+            <Form {...formProps} layout="vertical">
+                <Form.Item
+                    label="Id"
+                    name={["id"]}
+                    rules={[
+                        {
+                            required: true,
+                        },
+                    ]}
+                >
+                    <Input readOnly disabled />
+                </Form.Item>
+                <Form.Item
+                    label="Lesson"
+                    name={"lesson_id"}
+                    rules={[
+                        {
+                            required: true,
+                        },
+                    ]}
+                >
+                    <Select {...lessonSelectProps} />
+                </Form.Item>
+                <Form.Item
+                    label="Start Time"
+                    name={["start_time"]}
+                    rules={[
+                        {
+                            required: true,
+                        },
+                    ]}
+                    getValueProps={(value) => ({
+                        value: value ? dayjs(value) : undefined,
+                    })}
+                >
+                    <DatePicker />
+                </Form.Item>
+                <Form.Item
+                    label="End Time"
+                    name={["end_time"]}
+                    rules={[
+                        {
+                            required: true,
+                        },
+                    ]}
+                    getValueProps={(value) => ({
+                        value: value ? dayjs(value) : undefined,
+                    })}
+                >
+                    <DatePicker />
+                </Form.Item>
+                <Form.Item
+                    label="Status"
+                    name={["status"]}
+                    rules={[
+                        {
+                            required: true,
+                        },
+                    ]}
+                >
+                    <Input />
+                </Form.Item>
+                <Form.Item
+                    label="Created At"
+                    name={["created_at"]}
+                    rules={[
+                        {
+                            required: true,
+                        },
+                    ]}
+                    getValueProps={(value) => ({
+                        value: value ? dayjs(value) : undefined,
+                    })}
+                >
+                    <DatePicker />
+                </Form.Item>
+                <Form.Item
+                    label="Updated At"
+                    name={["updated_at"]}
+                    rules={[
+                        {
+                            required: true,
+                        },
+                    ]}
+                    getValueProps={(value) => ({
+                        value: value ? dayjs(value) : undefined,
+                    })}
+                >
+                    <DatePicker />
+                </Form.Item>
+            </Form>
+        </Edit>
+    );
 };

--- a/vite-app-ant/src/pages/reservations/show.tsx
+++ b/vite-app-ant/src/pages/reservations/show.tsx
@@ -1,85 +1,50 @@
+import React from "react";
 import { useShow, useOne } from "@refinedev/core";
-import { Card, Descriptions, Tag, Typography } from "antd";
-import dayjs from "dayjs";
+import { Show, TagField, TextField, DateField } from "@refinedev/antd";
+import { Typography } from "antd";
 
 const { Title } = Typography;
 
 export const ReservationsShow = () => {
-    const { queryResult } = useShow({
-        meta: {
-            select: "*, lesson_schedules(*, lessons(*), instructor:profiles(*)), student:profiles(*)",
+    const { queryResult } = useShow();
+    const { data, isLoading } = queryResult;
+
+    const record = data?.data;
+
+    const { data: lessonScheduleData, isLoading: lessonScheduleIsLoading } = useOne({
+        resource: "lesson_schedules",
+        id: record?.lesson_schedule_id || "",
+        queryOptions: {
+            enabled: !!record,
         },
     });
 
-    const { data, isLoading } = queryResult;
-    const record = data?.data;
-
-    const getStatusTag = (status: string) => {
-        const statusColors = {
-            申し込み: "processing",
-            申し込み承認: "success",
-            受講済: "default",
-            キャンセル: "error",
-        };
-        return <Tag color={statusColors[status as keyof typeof statusColors]}>{status}</Tag>;
-    };
-
-    if (isLoading) {
-        return <div>Loading...</div>;
-    }
+    const { data: profileData, isLoading: profileIsLoading } = useOne({
+        resource: "profiles",
+        id: record?.student_profile_id || "",
+        queryOptions: {
+            enabled: !!record,
+        },
+    });
 
     return (
-        <div style={{ padding: "16px" }}>
-            <Title level={4}>予約詳細</Title>
-            <Card>
-                <Descriptions title="予約基本情報" bordered>
-                    <Descriptions.Item label="予約番号">{record?.reservation_number}</Descriptions.Item>
-                    <Descriptions.Item label="ステータス">
-                        {record?.status && getStatusTag(record.status)}
-                    </Descriptions.Item>
-                    <Descriptions.Item label="予約日時">
-                        {dayjs(record?.created_at).format("YYYY年MM月DD日 HH時mm分")}
-                    </Descriptions.Item>
-                </Descriptions>
-
-                <Descriptions title="レッスン情報" bordered style={{ marginTop: "24px" }}>
-                    <Descriptions.Item label="レッスン名">
-                        {record?.lesson_schedules?.lessons?.name}
-                    </Descriptions.Item>
-                    <Descriptions.Item label="インストラクター">
-                        {record?.lesson_schedules?.instructor?.last_name} {record?.lesson_schedules?.instructor?.first_name}
-                    </Descriptions.Item>
-                    <Descriptions.Item label="開始時間">
-                        {dayjs(record?.lesson_schedules?.start_time).format("YYYY年MM月DD日 HH時mm分")}
-                    </Descriptions.Item>
-                    <Descriptions.Item label="終了時間">
-                        {dayjs(record?.lesson_schedules?.end_time).format("YYYY年MM月DD日 HH時mm分")}
-                    </Descriptions.Item>
-                    <Descriptions.Item label="レッスン料金">
-                        ¥{record?.lesson_schedules?.lessons?.price?.toLocaleString()}
-                    </Descriptions.Item>
-                </Descriptions>
-
-                <Descriptions title="生徒情報" bordered style={{ marginTop: "24px" }}>
-                    <Descriptions.Item label="氏名">
-                        {record?.student?.last_name} {record?.student?.first_name}
-                    </Descriptions.Item>
-                    <Descriptions.Item label="電話番号">
-                        {record?.student?.phone}
-                    </Descriptions.Item>
-                    <Descriptions.Item label="緊急連絡先">
-                        {record?.student?.emergency_contact}
-                    </Descriptions.Item>
-                </Descriptions>
-
-                {record?.instructor_comment && (
-                    <Descriptions title="インストラクターコメント" bordered style={{ marginTop: "24px" }}>
-                        <Descriptions.Item>
-                            {record.instructor_comment}
-                        </Descriptions.Item>
-                    </Descriptions>
-                )}
-            </Card>
-        </div>
+        <Show isLoading={isLoading}>
+            <Title level={5}>予約ID</Title>
+            <TextField value={record?.id} />
+            <Title level={5}>レッスンスケジュール</Title>
+            {lessonScheduleIsLoading ? <>Loading...</> : <>{lessonScheduleData?.data?.id}</>}
+            <Title level={5}>予約者</Title>
+            {profileIsLoading ? <>Loading...</> : <>{`${profileData?.data?.last_name} ${profileData?.data?.first_name}`}</>}
+            <Title level={5}>予約番号</Title>
+            <TextField value={record?.reservation_number} />
+            <Title level={5}>ステータス</Title>
+            <TextField value={record?.status} />
+            <Title level={5}>インストラクターコメント</Title>
+            <TextField value={record?.instructor_comment} />
+            <Title level={5}>作成日時</Title>
+            <DateField value={record?.created_at} format="YYYY年MM月DD日 HH時mm分" />
+            <Title level={5}>更新日時</Title>
+            <DateField value={record?.updated_at} format="YYYY年MM月DD日 HH時mm分" />
+        </Show>
     );
 };

--- a/vite-app-ant/src/pages/user_levels/show.tsx
+++ b/vite-app-ant/src/pages/user_levels/show.tsx
@@ -1,5 +1,28 @@
-import { AntdInferencer } from "@refinedev/inferencer/antd";
+import React from "react";
+import { useShow } from "@refinedev/core";
+import { Show, TagField, TextField, DateField } from "@refinedev/antd";
+import { Typography } from "antd";
+
+const { Title } = Typography;
 
 export const UserLevelsShow = () => {
-    return <AntdInferencer />;
+    const { queryResult } = useShow();
+    const { data, isLoading } = queryResult;
+
+    const record = data?.data;
+
+    return (
+        <Show isLoading={isLoading}>
+            <Title level={5}>ユーザーレベルID</Title>
+            <TextField value={record?.id} />
+            <Title level={5}>レベル名</Title>
+            <TextField value={record?.name} />
+            <Title level={5}>説明</Title>
+            <TextField value={record?.description} />
+            <Title level={5}>作成日時</Title>
+            <DateField value={record?.created_at} format="YYYY年MM月DD日 HH時mm分" />
+            <Title level={5}>更新日時</Title>
+            <DateField value={record?.updated_at} format="YYYY年MM月DD日 HH時mm分" />
+        </Show>
+    );
 };

--- a/vite-app-ant/src/providers/i18n-provider.tsx
+++ b/vite-app-ant/src/providers/i18n-provider.tsx
@@ -1,0 +1,37 @@
+import { I18nProvider } from "@refinedev/core";
+
+/**
+ * Check out the I18n Provider documentation for detailed information
+ * https://refine.dev/docs/api-reference/core/providers/i18n-provider/
+ **/
+export const i18nProvider: I18nProvider = {
+  translate: (key: string, options?: any, defaultMessage?: string) => {
+    console.log("translate", {
+      key,
+      options,
+      defaultMessage,
+    });
+
+    // TODO: do the translation
+
+    return defaultMessage || "";
+  },
+
+  changeLocale: (lang: string, options?: any) => {
+    console.log("changeLocale", {
+      lang,
+      options,
+    });
+
+    // TODO: change the locale
+
+    return Promise.resolve();
+  },
+  getLocale: () => {
+    console.log("getLocale");
+
+    // TODO: get the locale
+
+    return "en";
+  },
+};


### PR DESCRIPTION
# 概要
ダッシュボードの予約数カウントとUIの日本語化を実装しました。

# 変更内容
- ダッシュボードの予約数カウントクエリを修正
  - キャンセルされていない予約の数を正しくカウントするように修正
  - 予約データの取得方法を改善
- 詳細表示画面（show.tsx）の日本語化
  - 各種タイトルとラベルを日本語に変更
  - 日付と時刻のフォーマットを日本語形式に統一（YYYY年MM月DD日 HH時mm分）